### PR TITLE
Update keyword matching and highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
++ Unreleased
+    - improved keyword matching
+
 + 3.3.5
     - added `initWidth` column property for autoColumnWidth: supports numeric or function-returned initial widths while still participating in `widthWeight` distribution
     - updated autoColumnWidth docs, demo page, type definitions, and tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 + Unreleased
-    - improved keyword matching
+    - improved keyword matching including quoted phrases, negation prefixes and case-sensitive filtering
 
 + 3.3.5
     - added `initWidth` column property for autoColumnWidth: supports numeric or function-returned initial widths while still participating in `widthWeight` distribution

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ TurboGrid is a high-performance JavaScript data grid library with zero dependenc
 - **Auto Column Width** — Distribute remaining horizontal space proportionally across columns; fixed-width columns are excluded; use `widthWeight` per column to control the share
 - **Frozen Panes** — Freeze rows and columns at any edge (top/bottom/left/right) with configurable limits
 - **Row Operations** — Selection (single/multiple), drag & drop reordering, move, add/delete, row numbering
-- **Sorting & Filtering** — Built-in type-aware sorting (string/number/date/boolean), custom comparers, row filtering with keyword highlighting
+- **Sorting** — Built-in type-aware sorting (string/number/date/boolean) and custom comparers
+- **Filtering/Searching** — Row filtering with keyword highlighting (e.g.: `"string match"`, `-exclusion`, `case:Sensitive`)
 - **Rich Cell Rendering** — Formatter system for custom cell content — badges, progress bars, icons, checkboxes, or framework components
 - **Data Export** — Export grid data with configurable column/row inclusion and private field stripping
 - **Comprehensive API** — 100+ methods, 50+ configuration options, and 36 event types covering the full lifecycle
@@ -99,7 +100,7 @@ TurboGrid provides 100+ public methods, 50+ configuration options, and 36 event 
 
 The API covers:
 
-- **Methods** — Data management, row/column CRUD, scrolling & navigation, rendering, selection, tree operations, export
+- **Methods** — Data management, row/column CRUD, scrolling & navigation, rendering, selection, filter/search syntax, tree operations, export
 - **Options** — Display, selection, sorting, frozen panes, scrollbar, performance tuning, theming
 - **Events** — Lifecycle (`onUpdated`, `onDestroy`), interaction (`onClick`, `onSort`, `onKeyDown`), scroll, selection, drag & drop
 - **Data Structures** — Column items, row items, and internal properties (`tg_*` namespace)

--- a/examples/pages/api-doc.vue
+++ b/examples/pages/api-doc.vue
@@ -1071,12 +1071,25 @@
           <a name="highlightKeywordsFilter">highlightKeywordsFilter(rowItem, columns, keywords)</a>
           <div>Helper used by rowFilter and highlightKeywords to match and mark keywords.</div>
           <div>
-            columns should be a list of column ids, and keywords is split on whitespace before matching.
+            columns should be a list of column ids. keywords is split on whitespace and supports advanced syntax:
           </div>
+          <ul>
+            <li>Basic case-insensitive search by default</li>
+            <li>Negate keywords with - or ! prefix</li>
+            <li>Make keywords case-sensitive with case: prefix</li>
+            <li>Double-quoted phrases are not split on whitespace (escape inner quotes with backslashes)</li>
+          </ul>
+          <div>Examples:</div>
+          <ul>
+            <li>flaky test - Finds rows containing 'flaky' and 'test'</li>
+            <li>-flaky test - Finds rows containing 'test' but not 'flaky'</li>
+            <li>case:test - Finds rows containing 'test' (case-sensitive)</li>
+            <li>"\"flaky\" test" - Finds rows containing '"flaky" test'</li>
+          </ul>
           <pre><code class="language-js">
                             grid.setOption({
                                 rowFilter: function(rowItem) {
-                                    return this.highlightKeywordsFilter(rowItem, ["name", "type"], "foo bar");
+                                    return this.highlightKeywordsFilter(rowItem, ["name", "type"], 'foo -case:"bar"');
                                 }
                             });
                         </code></pre>

--- a/src/grid/init-rows.js
+++ b/src/grid/init-rows.js
@@ -218,6 +218,52 @@ export default {
 
     },
 
+    // keywords separated by spaces
+    // double quotes create single keywords with spaces (inner quotes escaped with \)
+    // leading hyphen negates keywords
+    // 'case:' makes keywords case-sensitive
+    parseKeywords: function(keywordsStr) {
+        const parsed = [];
+        if (!keywordsStr) {
+            return parsed;
+        }
+        const regex = /(?<=^|\s)(-)?(case:)?(?:"((?:.(?:\\")?)+?)"|([^\s]+))(?=\s|$)/g;
+        let match;
+        while ((match = regex.exec(keywordsStr))) {
+            parsed.push({
+                text: match[3]?.replace(/\\"/g, '"') ?? match[4],
+                caseSensitive: match[2] === 'case:',
+                negate: match[1] === '-'
+            });
+        }
+        return parsed;
+    },
+
+    matchKeywords: function(keywords, text) {
+        const matches = [];
+        const lowerText = text.toLowerCase();
+        for (const keyword of keywords) {
+            const searchFor = keyword.caseSensitive ? keyword.text : keyword.text.toLowerCase();
+            const lowText = keyword.caseSensitive ? text : lowerText;
+            const foundIndex = lowText.indexOf(searchFor);
+            const found = foundIndex !== -1;
+            if (keyword.negate ? found : !found) {
+                return null;
+            }
+            if (!keyword.negate) {
+                matches.push({
+                    index: foundIndex,
+                    length: searchFor.length,
+                    text: text.slice(foundIndex, foundIndex + searchFor.length)
+                });
+            }
+        }
+        if (matches.length === 0) {
+            return null;
+        }
+        return matches;
+    },
+
     highlightKeywordsFilter: function(rowItem, columns, keywordsStr) {
 
         const {
@@ -233,27 +279,10 @@ export default {
             return true;
         }
 
-        const keywords = `${keywordsStr}`.trim().toLowerCase().split(/\s+/g).filter((s) => s);
+        const keywords = this.parseKeywords(keywordsStr);
         if (!keywords.length) {
             return true;
         }
-
-        let hasMatched = false;
-        const getTextMatched = (text) => {
-
-            const lowText = text.toLowerCase();
-
-            let startPos = 0;
-            for (const key of keywords) {
-                const index = lowText.indexOf(key, startPos);
-                if (index === -1) {
-                    return;
-                }
-                startPos = index + key.length;
-            }
-
-            return true;
-        };
 
         const getHtmlText = (html, id) => {
             const cacheKey = `${textKey}${id}`;
@@ -269,14 +298,6 @@ export default {
             return text;
         };
 
-        const getMatched = (str, id) => {
-            const isHtml = (/<\/?[a-z][\s\S]*>/i).test(str);
-            if (isHtml) {
-                str = getHtmlText(str, id);
-            }
-            return getTextMatched(str);
-        };
-
         let textHandler = function(_rowItem, id) {
             return _rowItem[id];
         };
@@ -284,6 +305,8 @@ export default {
             textHandler = textGenerator;
         }
 
+        const htmlRegex = /<\/?[a-z][\s\S]*>/i;
+        const allMatches = [];
         columns.forEach((id) => {
 
             const text = textHandler(rowItem, id);
@@ -295,16 +318,20 @@ export default {
             if (!str) {
                 return;
             }
-            const matched = getMatched(str, id);
-            if (matched) {
-                rowItem[`${highlightKey}${id}`] = matched;
-                hasMatched = true;
-                // keep in instance
-                this.highlightKeywords = keywords;
+            const isHtml = htmlRegex.test(str);
+            const htmlText = isHtml ? getHtmlText(str, id) : str;
+            const matches = this.matchKeywords(keywords, htmlText);
+            if (matches) {
+                rowItem[`${highlightKey}${id}`] = true;
+                allMatches.push(... matches);
             }
         });
+        if (allMatches.length) {
+            // keep actual text matches in instance
+            this.highlightKeywords = allMatches;
+        }
 
-        return hasMatched;
+        return allMatches.length !== 0;
 
     },
 
@@ -315,19 +342,19 @@ export default {
             return;
         }
 
-        const keywords = this.highlightKeywords;
-        if (!keywords) {
+        const allMatches = this.highlightKeywords;
+        if (!allMatches) {
             return;
         }
 
         if (!this.asyncHighlightKeywords) {
             this.asyncHighlightKeywords = Util.debounce(this.highlightKeywordsSync, 10);
         }
-        this.asyncHighlightKeywords.apply(this, [highlightCells, keywords]);
+        this.asyncHighlightKeywords.apply(this, [highlightCells, allMatches]);
 
     },
 
-    highlightKeywordsSync: function(highlightCells, keywords) {
+    highlightKeywordsSync: function(highlightCells, allMatches) {
 
         // https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API
         // there is no renderSettings in next tick
@@ -360,57 +387,56 @@ export default {
                 return;
             }
 
-            this.highlightTextNodes(allTextNodes, keywords);
+            this.highlightTextNodes(allTextNodes, allMatches);
 
         });
     },
 
-    highlightTextNodes: function(allTextNodes, keywords) {
+    highlightTextNodes: function(allTextNodes, allMatches) {
 
         const { highlightPre, highlightPost } = this.options.highlightKeywords;
 
-        let keyIndex = 0;
-        const nextKey = () => {
-            if (keyIndex >= keywords.length) {
-                keyIndex = 0;
-            }
-            return keywords[keyIndex++];
-        };
-
-        let key = nextKey();
-
         allTextNodes.forEach((textNode) => {
-            const text = textNode.textContent;
-            const lowText = text.toLowerCase();
-            const list = [];
-            let startPos = 0;
-            const textLength = text.length;
-            let hasKeyMatched = false;
-            while (startPos < textLength) {
-                const index = lowText.indexOf(key, startPos);
-                if (index === -1) {
-                    break;
+            const nodeText = textNode.textContent;
+            const matches = [];
+            const matchedRanges = [];
+            allMatches.forEach((match) => {
+                // use `text`, as `index` and `length` are not guaranteed in node text
+                const index = nodeText.indexOf(match.text);
+                if (index !== -1) {
+                    const relativeStart = index;
+                    const relativeEnd = index + match.text.length;
+                    let overlaps = false;
+                    for (const range of matchedRanges) {
+                        if (range[0] < relativeEnd && range[1] > relativeStart) {
+                            overlaps = true;
+                            break;
+                        }
+                    }
+                    if (!overlaps) {
+                        matches.push({
+                            index: relativeStart,
+                            length: match.text.length,
+                            text: match.text
+                        });
+                        matchedRanges.push([relativeStart, relativeEnd]);
+                    }
                 }
+            });
 
-                list.push(text.slice(startPos, index));
-                list.push(highlightPre);
-
-                startPos = index + key.length;
-                key = nextKey();
-                hasKeyMatched = true;
-
-                list.push(text.slice(index, startPos));
-                list.push(highlightPost);
-
-            }
-
-            if (hasKeyMatched) {
-                if (startPos < textLength) {
-                    list.push(text.slice(startPos, textLength));
-                }
-                //  console.log(list);
+            if (matches.length > 0) {
+                // reverse index sort
+                matches.sort((a, b) => b.index - a.index);
+                let highlightedText = nodeText;
+                matches.forEach(({
+                    index, length, text
+                }) => {
+                    const before = highlightedText.slice(0, index);
+                    const after = highlightedText.slice(index + length);
+                    highlightedText = before + highlightPre + text + highlightPost + after;
+                });
                 const spanNode = document.createElement('span');
-                spanNode.innerHTML = list.join('');
+                spanNode.innerHTML = highlightedText;
                 textNode.parentNode.replaceChild(spanNode, textNode);
             }
         });

--- a/src/grid/init-rows.js
+++ b/src/grid/init-rows.js
@@ -220,20 +220,20 @@ export default {
 
     // keywords separated by spaces
     // double quotes create single keywords with spaces (inner quotes escaped with \)
-    // leading hyphen negates keywords
+    // leading hyphen or exclamation mark negates keywords
     // 'case:' makes keywords case-sensitive
     parseKeywords: function(keywordsStr) {
         const parsed = [];
         if (!keywordsStr) {
             return parsed;
         }
-        const regex = /(?<=^|\s)(-)?(case:)?(?:"((?:.(?:\\")?)+?)"|([^\s]+))(?=\s|$)/g;
+        const regex = /(^|\s)([-!])?(case:)?(?:"((?:.(?:\\")?)+?)"|([^\s]+))(?=\s|$)/g;
         let match;
         while ((match = regex.exec(keywordsStr))) {
             parsed.push({
-                text: match[3]?.replace(/\\"/g, '"') ?? match[4],
-                caseSensitive: match[2] === 'case:',
-                negate: match[1] === '-'
+                text: match[4]?.replace(/\\"/g, '"') ?? match[5],
+                negate: ['-', '!'].includes(match[2]),
+                caseSensitive: match[3] === 'case:'
             });
         }
         return parsed;
@@ -254,14 +254,19 @@ export default {
                 matches.push({
                     index: foundIndex,
                     length: searchFor.length,
-                    text: text.slice(foundIndex, foundIndex + searchFor.length)
+                    text: text.slice(foundIndex, foundIndex + searchFor.length),
+                    caseSensitive: keyword.caseSensitive
                 });
             }
         }
-        if (matches.length === 0) {
+        if (this.noMatchingKeywords(keywords, matches)) {
             return null;
         }
         return matches;
+    },
+
+    noMatchingKeywords: function(keywords, matches) {
+        return matches.length === 0 && keywords.length > 0 && !(keywords.every((k) => k.negate));
     },
 
     highlightKeywordsFilter: function(rowItem, columns, keywordsStr) {
@@ -306,7 +311,7 @@ export default {
         }
 
         const htmlRegex = /<\/?[a-z][\s\S]*>/i;
-        const allMatches = [];
+        let allMatches = null;
         columns.forEach((id) => {
 
             const text = textHandler(rowItem, id);
@@ -321,17 +326,18 @@ export default {
             const isHtml = htmlRegex.test(str);
             const htmlText = isHtml ? getHtmlText(str, id) : str;
             const matches = this.matchKeywords(keywords, htmlText);
-            if (matches) {
+            if (matches !== null) {
                 rowItem[`${highlightKey}${id}`] = true;
+                allMatches = allMatches || [];
                 allMatches.push(... matches);
             }
         });
-        if (allMatches.length) {
+        if (allMatches !== null) {
             // keep actual text matches in instance
             this.highlightKeywords = allMatches;
         }
 
-        return allMatches.length !== 0;
+        return allMatches !== null;
 
     },
 
@@ -401,8 +407,12 @@ export default {
             const matches = [];
             const matchedRanges = [];
             allMatches.forEach((match) => {
-                // use `text`, as `index` and `length` are not guaranteed in node text
-                const index = nodeText.indexOf(match.text);
+                let index;
+                if (match.caseSensitive) {
+                    index = nodeText.indexOf(match.text);
+                } else {
+                    index = nodeText.toLowerCase().indexOf(match.text.toLowerCase());
+                }
                 if (index !== -1) {
                     const relativeStart = index;
                     const relativeEnd = index + match.text.length;
@@ -417,7 +427,7 @@ export default {
                         matches.push({
                             index: relativeStart,
                             length: match.text.length,
-                            text: match.text
+                            text: nodeText.slice(relativeStart, relativeEnd)
                         });
                         matchedRanges.push([relativeStart, relativeEnd]);
                     }

--- a/src/turbogrid.d.ts
+++ b/src/turbogrid.d.ts
@@ -170,6 +170,19 @@ export interface ColumnTypes {
 // =============================================================================
 // Highlight Keywords
 
+export interface Keyword {
+    text: string;
+    negate: boolean;
+    caseSensitive: boolean;
+}
+
+export interface KeywordMatch {
+    index: number;
+    length: number;
+    text: string;
+    caseSensitive: boolean;
+}
+
 export interface HighlightKeywords {
     textKey?: string;
     textGenerator?: ((rowItem: RowItem, id: string) => string) | null;
@@ -716,6 +729,10 @@ export declare class Grid extends EventBase {
     getCellValue(rowItem: RowItem, columnItem: ColumnItem): any;
 
     // Highlight
+    /** Parses a keyword string into an array of keyword objects */
+    parseKeywords(keywordsStr: string): Keyword[];
+    /** Matches keywords against text and returns matched positions, or null if there is no match */
+    matchKeywords(keywords: Keyword[], text: string): KeywordMatch[] | null;
     /** Helper for rowFilter to match and mark keywords across specified columns */
     highlightKeywordsFilter(rowItem: RowItem, columns: string[], keywords: string): boolean;
 

--- a/test/specs/row-filter.js
+++ b/test/specs/row-filter.js
@@ -247,9 +247,27 @@ describe('rowFilter and rowFilteredSort (invisible 15)', function() {
         assert.equal(values, '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19');
     });
 
-    it('Grid rowFilter: highlightKeywordsFilter', async () => {
+});
 
-        keywords = '1';
+describe('Grid rowFilter: highlightKeywordsFilter', function() {
+    let container;
+    let grid;
+    let keywords;
+
+    before(function() {
+        container = createContainer('500px', '500px');
+        grid = new Grid(container);
+    });
+    after(function() {
+        grid.destroy();
+        grid = null;
+        container.remove();
+        container = null;
+    });
+
+    it('basic', async () => {
+
+        keywords = '1 -11';
 
         const data = createData();
         grid.setData(data);
@@ -266,27 +284,30 @@ describe('rowFilter and rowFilteredSort (invisible 15)', function() {
         await delay(100);
 
         const rows = grid.getViewRows();
-        assert.equal(rows.length, 10);
+        const expected = [1, 10, 12, 13, 14, 16, 17, 18, 19];
+        assert.equal(rows.length, expected.length);
 
         const values = grid.getViewRows().map((it) => it.value).join(',');
-        assert.equal(values, '1,10,11,12,13,14,16,17,18,19');
+        assert.equal(values, expected.join(','));
 
-        // check mark tag
-        const row1 = grid.getViewRows()[0];
+        // check mark tags
+        for (let i = 0; i < expected.length; i++) {
+            const row = grid.getViewRows()[i];
 
-        const cellNode = grid.getCellNode(row1, 'name');
-        const mark = cellNode.querySelector('mark');
-        assert.ok(mark);
-        assert.equal(mark.innerText, keywords);
+            const cellNode = grid.getCellNode(row, 'name');
+            const mark = cellNode.querySelector('mark');
+            assert.ok(mark);
+            assert.equal(mark.innerText, '1');
+        }
     });
 
-    it('Grid rowFilter: highlightKeywordsFilter html', async () => {
+    it('html', async () => {
 
-        keywords = 're';
+        keywords = 're when';
 
         const data = createData();
         data.rows.push({
-            name: 'See <font color="red">red</font>'
+            name: 'When you see <font color="red">Red</font> on the screen, you know when'
         });
         grid.setData(data);
         grid.setOption({
@@ -301,13 +322,67 @@ describe('rowFilter and rowFilteredSort (invisible 15)', function() {
         // 100 for debounce
         await delay(100);
 
-        // check mark tag
+        // check mark tags
         const row1 = grid.getViewRows()[0];
 
         const cellNode = grid.getCellNode(row1, 'name');
-        const mark = cellNode.querySelector('font mark');
-        assert.ok(mark);
-        assert.equal(mark.innerText, keywords);
+        const marks = cellNode.querySelectorAll('mark');
+        assert.equal(marks.length, 2);
+        assert.equal(marks[0].innerText, 'When');
+        assert.equal(marks[1].innerText, 'Re');
+    });
+
+    it('complex', async () => {
+
+        keywords = 'case:Test "case 1" -@smoke';
+
+        const data = {
+            columns: [{
+                id: 'name',
+                name: 'Name'
+            }],
+            rows: [
+                {
+                    name: 'Example Case 1 Data Driven Test'
+                },
+                {
+                    // does not include case-sensitive 'Test'
+                    name: 'test case 1 fixme - not yet ready'
+                },
+                {
+                    // does not include 'case 1'
+                    name: 'Test case with custom steps 1'
+                },
+                {
+                    // includes '@smoke'
+                    name: '@smoke Test case 1 full report'
+                }
+            ]
+        };
+        grid.setData(data);
+        grid.setOption({
+            rowNotFound: 'No Results',
+            rowFilter: function(rowItem) {
+                return this.highlightKeywordsFilter(rowItem, ['name'], keywords);
+            }
+        });
+
+        grid.render();
+
+        // 100 for debounce
+        await delay(100);
+
+        const rows = grid.getViewRows();
+        assert.equal(rows.length, 1);
+
+        // check mark tags
+        const row1 = grid.getViewRows()[0];
+
+        const cellNode = grid.getCellNode(row1, 'name');
+        const marks = cellNode.querySelectorAll('mark');
+        assert.equal(marks.length, 2);
+        assert.equal(marks[0].innerText, 'Case 1');
+        assert.equal(marks[1].innerText, 'Test');
     });
 
 });

--- a/test/specs/row-filter.js
+++ b/test/specs/row-filter.js
@@ -322,14 +322,19 @@ describe('Grid rowFilter: highlightKeywordsFilter', function() {
         // 100 for debounce
         await delay(100);
 
+        const rows = grid.getViewRows();
+        assert.equal(rows.length, 1);
+
         // check mark tags
         const row1 = grid.getViewRows()[0];
 
         const cellNode = grid.getCellNode(row1, 'name');
         const marks = cellNode.querySelectorAll('mark');
-        assert.equal(marks.length, 2);
+        assert.equal(marks.length, 4);
         assert.equal(marks[0].innerText, 'When');
         assert.equal(marks[1].innerText, 'Re');
+        assert.equal(marks[2].innerText, 're');
+        assert.equal(marks[3].innerText, 'when');
     });
 
     it('complex', async () => {
@@ -383,6 +388,28 @@ describe('Grid rowFilter: highlightKeywordsFilter', function() {
         assert.equal(marks.length, 2);
         assert.equal(marks[0].innerText, 'Case 1');
         assert.equal(marks[1].innerText, 'Test');
+    });
+
+    it('negated', async () => {
+
+        keywords = '-0 -15';
+
+        const data = createData();
+        grid.setData(data);
+        grid.setOption({
+            rowNotFound: 'No Results',
+            rowFilter: function(rowItem) {
+                return this.highlightKeywordsFilter(rowItem, ['name'], keywords);
+            }
+        });
+
+        grid.render();
+
+        // 100 for debounce
+        await delay(100);
+
+        const rows = grid.getViewRows();
+        assert.equal(rows.length, data.rows.length - 3);
     });
 
 });


### PR DESCRIPTION
**Motivation**
Currently, `turbogrid`'s row searching functionality is very simple. When there are a lot of rows, it can become difficult to filter to a subset of them, especially when that subset has complex conditions.

This pull request was created in response to the discussion had in [`monocart-reporter` closed pull request 204](https://github.com/cenfun/monocart-reporter/pull/204). Below is a list of complex searches for said package that are impossible with the current implementation:

- Filtering by multiple conditions (e.g., 'TestSource @ tag')
- Negating the appearance of a tag (e.g., '-@ smoke')

**Feature**
In `src/grid/init-rows.js`:
- The function `parseKeywords()` has been added to convert a search query into the object array `{ text: string; caseSensitive: boolean; negate: boolean; }[]`.
- The function `matchKeywords()` has been added, replacing `getTextMatched()`. It returns the actual text matches as a separate object array `{ index: number; length: number; text: string; }[]`. These objects are later parsed by `highlightTextNodes()`.
- `highlightTextNodes()` has been updated to support highlighting by object matches, using the `text` property due to node text mismatches between searching and highlighting.

**Coverage**
The 'Grid rowFilter: highlightKeywordsFilter' tests in `test/specs/row-filter.js` have been updated to include the new searching features (affected tests have been separated out into a new test suite to satisfy the complexity limit):
- 'basic': In addition to searching for '1', now negates '11'.
- 'html': Now searches for two words, one outside and one inside HTML tags.
- 'complex': A new test that filters by a case-sensitive keyword, an exact string and a negated string.

**Caveat**
Despite this pull request effectively replacing the one made to `monocart-reporter`, [restoring tags only if the search input is unfocused in `app.vue`](https://github.com/cenfun/monocart-reporter/pull/204/changes/ec887166759f6694089a66e08b7a70fb0d29409f#diff-f21dec9fa730fa5f800708017a85f814dcfe8f78d2c22ea65c1e03c019daf65d) is still recommended to be implemented in said repository, as it allows for complex search queries to be entered without them being auto-formatted to remove query characters.